### PR TITLE
Put services in node namespace

### DIFF
--- a/scripts/player.py
+++ b/scripts/player.py
@@ -16,8 +16,8 @@ class Player(object):
 
     def __init__(self):
         # services
-        self.srv_play         = rospy.Service('play',         Play,      self.play_srv)
-        self.srv_clear_buffer = rospy.Service('clear_buffer', Empty,     self.clear_buffer_srv)
+        self.srv_play         = rospy.Service('~play',         Play,      self.play_srv)
+        self.srv_clear_buffer = rospy.Service('~clear_buffer', Empty,     self.clear_buffer_srv)
 
         # buffer audio requests
         self.buffer = []


### PR DESCRIPTION
Put the service in the namespace of the audio player. This was already done for the `play` service in the launch file. But the `clear_buffer` service wasn't adjusted.

I have checked and no node used the `clear_buffer` service. And the `play` service doesn't actually change its name. So nothing breaks.

Merge together with https://github.com/tue-robotics/robot_launch_files/pull/52